### PR TITLE
[BUGFIX] Resets list view after dragging

### DIFF
--- a/app/templates/components/dragon-drop.hbs
+++ b/app/templates/components/dragon-drop.hbs
@@ -1,3 +1,5 @@
-{{#each model as |item|}}
-  {{yield item}}
-{{/each}}
+{{#if listVisible}}
+  {{#each model as |item|}}
+    {{yield item}}
+  {{/each}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-dragon-drop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A drag and drop library for Ember.js, based on dragula.js",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Seems to work pretty well without any flickering of elements or artificats. Somewhat hacky however...

Found this solution here:
http://stackoverflow.com/questions/32587495/resolving-ember-and-dragulas-view-of-the-dom

The author of the solution also wrote about it in this blog:
http://haughtcodeworks.com/blog/software-development/bridging-dragula-and-ember/

----

Also included:

- Re-formats syntax to not use `.on` bindings
- Added docs